### PR TITLE
Fix clasp clone

### DIFF
--- a/src/clasp-helper.ts
+++ b/src/clasp-helper.ts
@@ -167,13 +167,17 @@ export class ClaspHelper {
   ) {
     await this.clean(rootDir);
 
-    this.writeConfig(scriptIdDev, rootDir);
+    // Write .clasp.json
+    await this.writeConfig(scriptIdDev, rootDir);
+
+    // Copy .clasp.json to clasp root dir
+    await fs.copyFile('.clasp.json', path.join(rootDir, '.clasp.json'));
 
     spawn.sync('npx', ['clasp', 'clone'], { stdio: 'inherit' });
-
     spawn.sync('npx', ['clasp', 'pull'], { stdio: 'inherit' });
 
-    this.arrangeFiles(rootDir, scriptIdProd);
+    // Copy/Move files to their designated place
+    await this.arrangeFiles(rootDir, scriptIdProd);
   }
 
   /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -101,7 +101,7 @@ export async function handlePackageJson(options: Options) {
   console.log(`${chalk.green('\u2714')}`, 'Adding scripts...');
   const existingScripts = packageJson.getScripts();
   for (const [name, script] of Object.entries(config.scripts)) {
-    if (name in existingScripts) {
+    if (name in existingScripts && existingScripts[name] !== script) {
       const replace = await query(
         `package.json already has a script for ${chalk.bold(name)}:\n` +
           `-${chalk.red(existingScripts[name])}\n+${chalk.green(script)}`,


### PR DESCRIPTION
- Fixed issue where Apps Script ID would not be respected for `clasp clone` because the `.clasp.json` was not in the right location
- Fixed check for existing scripts when generating `package.json` because they were not checked for equality