### PR TITLE
Fixed clasp setup

### DIFF
--- a/src/clasp-helper.ts
+++ b/src/clasp-helper.ts
@@ -148,7 +148,7 @@ export class ClaspHelper {
     await fs.move(path.join(rootDir, 'appsscript.json'), 'appsscript.json');
 
     if (scriptIdProd) {
-      this.writeConfig(scriptIdProd, '.clasp-prod.json');
+      this.writeConfig(scriptIdProd, rootDir, '.clasp-prod.json');
     } else {
       await fs.copyFile('.clasp-dev.json', '.clasp-prod.json');
     }

--- a/test/clasp-helper.test.ts
+++ b/test/clasp-helper.test.ts
@@ -192,7 +192,11 @@ describe('clasp-helper', () => {
 
       await claspHelper.arrangeFiles('rootDir', 'abc123');
 
-      expect(writeConfigSpy).toHaveBeenCalledWith('abc123', '.clasp-prod.json');
+      expect(writeConfigSpy).toHaveBeenCalledWith(
+        'abc123',
+        'rootDir',
+        '.clasp-prod.json'
+      );
     });
   });
 


### PR DESCRIPTION
Due to the missing 'rootDir' parameter with `this.writeConfig(scriptIdProd, '.clasp-prod.json');` in `arrangeFiles()` the tool created a `.clasp.json` with `dist` set to `.clasp-prod.json`.

Added the missing parameter to fix the issue.