### PR TITLE
Fix Angular Material animations in Apps Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,23 +118,6 @@ import './path/to/module';
 
 This will ensure that Rollup will not remove it from the bundle.
 
-### The UI is not working on Apps Script
-
-When installing Angular Material, if you chose `Include and enable animations`, you need to make some changes to `src/ui/src/app/app.config.ts`.
-
-ASIDE currently doesn't support chunk files which will be generated for lazy-loading through `provideAnimationsAsync()`.
-
-Change `app.config.ts` to:
-
-```
-import { ApplicationConfig } from '@angular/core';
-import { provideAnimations } from '@angular/platform-browser/animations';
-
-export const appConfig: ApplicationConfig = {
-  providers: [provideAnimations()]
-};
-```
-
 ## Disclaimer
 
 This is not an officially supported Google product.

--- a/fix-animations.mjs
+++ b/fix-animations.mjs
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import fs from 'fs-extra';
+import path from 'path';
+
+const cwd = process.cwd();
+const appFolder = path.join(cwd, 'src/ui/src/app');
+const appConfigPath = path.join(appFolder, 'app.config.ts');
+
+let appConfig = fs.readFileSync(appConfigPath).toString();
+
+appConfig = appConfig
+  .replaceAll(
+    `import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';`,
+    `import { provideAnimations } from '@angular/platform-browser/animations';`
+  )
+  .replaceAll('provideAnimationsAsync()', 'provideAnimations()');
+
+fs.writeFileSync(appConfigPath, appConfig);

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bin": "dist/src/index.js",
   "files": [
     "deploy-ui.mjs",
+    "fix-animations.mjs",
     "dist/src",
     "dist/.gitignore-target",
     ".claspignore",

--- a/src/config.ts
+++ b/src/config.ts
@@ -127,7 +127,8 @@ export const configForUi: {
     'deploy:prod':
       'npm run lint && npm run test && npm run build && ncp appsscript.json dist/appsscript.json && ncp .clasp-prod.json .clasp.json && npm run build-ui && npm run deploy-ui && clasp push',
     'serve-ui': 'cd src/ui && ng serve',
-    'postinstall': 'cd src/ui && npm install',
+    'fix-animations': 'node fix-animations.mjs',
+    'postinstall': 'npm run fix-animations && cd src/ui && npm install',
   },
   filesCopy: {
     '.editorconfig': '.editorconfig',
@@ -139,6 +140,7 @@ export const configForUi: {
     'license-header.txt': 'license-header.txt',
     'rollup.config.mjs': 'rollup.config.mjs',
     'deploy-ui.mjs': 'deploy-ui.mjs',
+    'fix-animations.mjs': 'fix-animations.mjs',
     'tsconfig.json': 'tsconfig.json',
   },
   filesMerge: {


### PR DESCRIPTION
By default, Angular Material includes `provideAnimationsAsync()`, which generates chunk files not supported currently by ASIDE.

This is fixed by a node script modifying `app.config.ts` and using `provideAnimations()` instead.