### PR TITLE
Update year in license-header.txt

### DIFF
--- a/license-header.txt
+++ b/license-header.txt
@@ -1,4 +1,4 @@
-Copyright 2023 Google LLC
+Copyright 2025 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Not having the correct year breaks the license check and causes a new license to be added every time you correct it in your code.