### PR TITLE
Adding rollup-plugin-google-apps-script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,24 @@ import './path/to/module';
 
 This will ensure that Rollup will not remove it from the bundle.
 
+### Linter not allowing unused variables
+
+A [plugin for Google App Script](https://github.com/mato533/rollup-plugin-gas) is included in the Rollup configuration. This automatically creates top-level functions for anything declared on the global object. To avoid unused variables in your code, first use `declare global` to declare the functions you need, and then assign the actual function to your declaration. e.g.:
+
+```ts
+declare global {
+  onOpen(): void;
+}
+
+function onOpenFunc(): void {
+  SpreadsheetApp.getUI().createMenu('Stuff').addToUI();
+}
+
+global.onOpen = onOpenFunc;
+```
+
+This would result in a top-level `onOpen` function being created in the build results.
+
 ## Disclaimer
 
 This is not an officially supported Google product.

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "prettier": "^2.8.5",
         "rimraf": "^4.4.0",
         "rollup": "^3.20.0",
+        "rollup-plugin-google-apps-script": "^2.0.2",
         "ts-jest": "^29.0.5",
         "tslib": "^2.5.0",
         "typescript": "^4.9.5"
@@ -3033,6 +3034,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/eslint": {
       "version": "8.36.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
@@ -3409,6 +3442,20 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esprima-next": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/esprima-next/-/esprima-next-6.0.3.tgz",
+      "integrity": "sha512-fVfE+9qIOJSbS3AR7roIuL0gCeS+tC86bJV9GlJtwXCRoo67q6tsGGUjThW+JtR5IQSShnHqaDqX8D0IYDfRGA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/esquery": {
@@ -3792,6 +3839,28 @@
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/gas-entry-generator": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/gas-entry-generator/-/gas-entry-generator-2.6.0.tgz",
+      "integrity": "sha512-iO1AM+6+H5TySmbRVadyDegVObchFkB+DqrUwVryKc28HxTZd4HpaRxTe3cKT2pzyMMP0UIMt0j7NsLV26OSkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "escodegen": "2.1.0",
+        "esprima-next": "^6.0.2",
+        "estraverse": "5.3.0"
+      }
+    },
+    "node_modules/gas-entry-generator/node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -7969,10 +8038,11 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -8554,9 +8624,10 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.0.tgz",
-      "integrity": "sha512-YsIfrk80NqUDrxrjWPXUa7PWvAfegZEXHuPsEZg58fGCdjL1I9C1i/NaG+L+27kxxwkrG/QEDEQc8s/ynXWWGQ==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
+      "license": "MIT",
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -8581,6 +8652,30 @@
       },
       "peerDependencies": {
         "rollup": ">=2.0"
+      }
+    },
+    "node_modules/rollup-plugin-google-apps-script": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-google-apps-script/-/rollup-plugin-google-apps-script-2.0.2.tgz",
+      "integrity": "sha512-P8QuOnH8n4kbRnZACUg8cWA1gNE5yxFfMWb1JBgIIg9UlOCM/QUJt2c5y+COV/W3USt2GMrwfni00lmNS1ou4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gas-entry-generator": "^2.6.0",
+        "picocolors": "^1.1.1",
+        "rollup-pluginutils": "^2.8.2"
+      },
+      "peerDependencies": {
+        "rollup": "^3.25.0 || ^4.0.0",
+        "vite": "^4.4.9"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/rollup-plugin-license": {
@@ -11868,6 +11963,26 @@
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true
     },
+    "escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        }
+      }
+    },
     "eslint": {
       "version": "8.36.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
@@ -12116,6 +12231,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esprima-next": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/esprima-next/-/esprima-next-6.0.3.tgz",
+      "integrity": "sha512-fVfE+9qIOJSbS3AR7roIuL0gCeS+tC86bJV9GlJtwXCRoo67q6tsGGUjThW+JtR5IQSShnHqaDqX8D0IYDfRGA==",
       "dev": true
     },
     "esquery": {
@@ -12402,6 +12523,25 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
+    },
+    "gas-entry-generator": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/gas-entry-generator/-/gas-entry-generator-2.6.0.tgz",
+      "integrity": "sha512-iO1AM+6+H5TySmbRVadyDegVObchFkB+DqrUwVryKc28HxTZd4HpaRxTe3cKT2pzyMMP0UIMt0j7NsLV26OSkA==",
+      "dev": true,
+      "requires": {
+        "escodegen": "2.1.0",
+        "esprima-next": "^6.0.2",
+        "estraverse": "5.3.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+          "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+          "dev": true
+        }
+      }
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -15398,9 +15538,9 @@
       "integrity": "sha512-L7MXxUDtqr4PUaLFCDCXBfGV/6KLIuSEccizDI7JxT+c9x1G1v04BQ4+4oag84SHaCdrBgQAIs/Cqn+flwFPng=="
     },
     "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
     },
     "picomatch": {
@@ -15784,9 +15924,9 @@
       }
     },
     "rollup": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.20.0.tgz",
-      "integrity": "sha512-YsIfrk80NqUDrxrjWPXUa7PWvAfegZEXHuPsEZg58fGCdjL1I9C1i/NaG+L+27kxxwkrG/QEDEQc8s/ynXWWGQ==",
+      "version": "3.29.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.5.tgz",
+      "integrity": "sha512-GVsDdsbJzzy4S/v3dqWPJ7EfvZJfCHiDqe80IyrF59LYuP+e6U1LJoUqeuqRbwAWoMNoXivMNeNAOf5E22VA1w==",
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -15797,6 +15937,17 @@
       "integrity": "sha512-zuv8EhoO3TpnrU8MX8W7YxSbO4gmOR0ny06Lm3nkFfq0IVKdBUtHwhVzY1OAJyNCIAdLiyPnOrU0KnO0Fri1GQ==",
       "requires": {
         "js-cleanup": "^1.2.0",
+        "rollup-pluginutils": "^2.8.2"
+      }
+    },
+    "rollup-plugin-google-apps-script": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-google-apps-script/-/rollup-plugin-google-apps-script-2.0.2.tgz",
+      "integrity": "sha512-P8QuOnH8n4kbRnZACUg8cWA1gNE5yxFfMWb1JBgIIg9UlOCM/QUJt2c5y+COV/W3USt2GMrwfni00lmNS1ou4Q==",
+      "dev": true,
+      "requires": {
+        "gas-entry-generator": "^2.6.0",
+        "picocolors": "^1.1.1",
         "rollup-pluginutils": "^2.8.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "prettier": "^2.8.5",
     "rimraf": "^4.4.0",
     "rollup": "^3.20.0",
+    "rollup-plugin-google-apps-script": "^2.0.2",
     "ts-jest": "^29.0.5",
     "tslib": "^2.5.0",
     "typescript": "^4.9.5"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -16,6 +16,7 @@
 import cleanup from 'rollup-plugin-cleanup';
 import license from 'rollup-plugin-license';
 import prettier from 'rollup-plugin-prettier';
+import rollupPluginGas from 'rollup-plugin-google-apps-script';
 import typescript from 'rollup-plugin-typescript2';
 import { fileURLToPath } from 'url';
 
@@ -36,6 +37,7 @@ export default {
     }),
     typescript(),
     prettier({ parser: 'typescript' }),
+    rollupPluginGas(),
   ],
   context: 'this',
 };


### PR DESCRIPTION
Some dev shops don't allow code with unused variables (or functions) to be merged. The Apps Script plugins allows such people to write code that appeases the linter, and that works when deployed.