### PR TITLE
Update to license check to use the current year.

### DIFF
--- a/license-config.json
+++ b/license-config.json
@@ -1,4 +1,5 @@
 {
+  "regexIdentifier": "%%",
   "ignore": [
     ".claspignore",
     ".editorconfig",
@@ -18,7 +19,9 @@
     "eslint.config.js",
     "eslint.config.cjs",
     "src/ui/.angular",
-    "src/ui/.prettierrc"
+    "src/ui/.prettierrc",
+    "node_modules",
+    "license-config.json"
   ],
   "license": "license-header.txt",
   "licenseFormats": {

--- a/license-header.txt
+++ b/license-header.txt
@@ -1,4 +1,4 @@
-Copyright 2025 Google LLC
+Copyright %%[0-9]{4}%% Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "npm run license && eslint --fix src/ test/",
     "lint:staged": "npm run license && lint-staged",
     "build": "npm run clean && npm run lint && tsc && npm run copy-files",
-    "license": "license-check-and-add add -f license-config.json",
+    "license": "license-check-and-add add -f license-config.json -r $(date +%Y)",
     "test": "jest test/ --detectOpenHandles",
     "copy-files": "ncp .gitignore dist/.gitignore-target",
     "prepare": "is-ci || husky install"

--- a/src/config.ts
+++ b/src/config.ts
@@ -51,7 +51,7 @@ export const config: {
     bundle: 'rollup --no-treeshake -c rollup.config.mjs',
     build:
       'npm run clean && npm run bundle && ncp appsscript.json dist/appsscript.json',
-    license: 'license-check-and-add add -f license-config.json',
+    license: 'license-check-and-add add -f license-config.json -r $(date +%Y)',
     test: 'jest test/ --passWithNoTests --detectOpenHandles',
     deploy:
       'npm run lint && npm run test && npm run build && ncp .clasp-dev.json .clasp.json && clasp push -f',
@@ -117,7 +117,7 @@ export const configForUi: {
     bundle: 'rollup --no-treeshake -c rollup.config.mjs',
     build: 'npm run clean && npm run bundle',
     'build-ui': 'npm run build --prefix src/ui',
-    license: 'license-check-and-add add -f license-config.json',
+    license: 'license-check-and-add add -f license-config.json -r $(date +%Y)',
     test: 'jest test/ --passWithNoTests --detectOpenHandles',
     'test-ui': 'npm run test --prefix src/ui',
     deploy:


### PR DESCRIPTION
This updates the add license code to use the current year when the license header is added and to ignore files where the license header already exists.