### PR TITLE
Excluded `src/ui` from `/tsconfig.json`

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -42,7 +42,7 @@ module.exports = [
     files: ['**/*.ts', '**/*.tsx'],
     languageOptions: {
       parserOptions: {
-        project: ['./tsconfig.json'],
+        project: ['./tsconfig.json', './src/ui/tsconfig.app.json'],
       },
     },
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,5 @@
     "types": ["jest", "node", "google-apps-script"]
   },
   "include": ["src/**/*", "test/**/*", "rollup.config.mjs"],
-  "exclude": ["src/ui"]
+  "exclude": ["src/ui/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,6 @@
     "allowUnusedLabels": false,
     "types": ["jest", "node", "google-apps-script"]
   },
-  "include": ["src/**/*", "test/**/*", "rollup.config.mjs"]
+  "include": ["src/**/*", "test/**/*", "rollup.config.mjs"],
+  "exclude": ["src/ui"]
 }


### PR DESCRIPTION
Excluded `src/ui` from `/tsconfig.json` so that the Angular Language Server only uses the intended `src/ui/tsconfig.json`.

Fixes #50